### PR TITLE
Create a common artifacts folder

### DIFF
--- a/src/api/mediaObject.ts
+++ b/src/api/mediaObject.ts
@@ -100,6 +100,8 @@ export interface MediaObject extends PouchDB.Core.IdMeta, PouchDB.Core.GetMeta {
 	thumbSize: number
 	/** Thumbnail last updated timestamp */
 	thumbTime: number
+	/** Thumbnail path */
+	thumbPath?: string
 
 	/** Preview file size in bytes */
 	previewSize?: number

--- a/src/app.ts
+++ b/src/app.ts
@@ -60,7 +60,7 @@ export class MediaManagerApp {
 			ctx.type = 'video/webm'
 			let previewPath = path.join(
 				this.config.paths && this.config.paths.resources || '',
-				this.config.previews && this.config.previews.folder || '',
+				this.config.previews && this.config.previews.folder || 'previews',
 				`${id}.webm`
 			)
 			let { result: stats, error: statError } = await noTryAsync(() => fs.stat(previewPath))

--- a/src/configManifest.ts
+++ b/src/configManifest.ts
@@ -242,7 +242,7 @@ export const MEDIA_MANAGER_CONFIG_MANIFEST: DeviceConfigManifest = {
 			id: 'thumbnails.folder',
 			name: 'Thumbnail sub-folder',
 			type: ConfigManifestEntryType.STRING,
-			placeholder: 'thumbnails'
+			placeholder: 'thumbs'
 		},
 		{
 			id: 'metadata.fieldOrder',

--- a/src/mediaManager.ts
+++ b/src/mediaManager.ts
@@ -15,7 +15,7 @@ import { Process } from './process'
 import { MonitorManager } from './monitors/manager'
 import * as PouchDB from 'pouchdb-node'
 import { MediaManagerApp } from './app'
-import { PreviewVacuum } from './monitors/previewVacuum'
+import { PreviewAndThumbnailVacuum } from './monitors/previewVacuum'
 import { buildStorageHandler } from './storageHandlers/storageHandlerFactory'
 
 export type SetProcessState = (processName: string, comments: string[], status: P.StatusCode) => void
@@ -55,7 +55,7 @@ export class MediaManager {
 	private mediaDB: PouchDB.Database<MediaObject>
 	private _monitorManager: MonitorManager
 	private _app: MediaManagerApp
-	private vac: PreviewVacuum | null = null
+	private vac: PreviewAndThumbnailVacuum | null = null
 
 	constructor(logger: Winston.LoggerInstance) {
 		this._logger = logger
@@ -98,7 +98,7 @@ export class MediaManager {
 			await this.initServer(peripheralDevice.settings || {})
 			this._logger.info('HTTP/S servers initialized')
 
-			this.vac = new PreviewVacuum(this.mediaDB, peripheralDevice.settings || {}, this._logger)
+			this.vac = new PreviewAndThumbnailVacuum(this.mediaDB, peripheralDevice.settings || {}, this._logger)
 			this._logger.info('Preview vacuum initialized')
 
 			this._logger.info('Initialization done')
@@ -137,7 +137,7 @@ export class MediaManager {
 	}
 
 	async initServer(settings: DeviceSettings) {
-		this._app = new MediaManagerApp(settings, this.mediaDB, this._logger)
+		this._app = new MediaManagerApp(settings, this._logger)
 		return this._app.init()
 	}
 

--- a/src/monitors/previewVacuum.ts
+++ b/src/monitors/previewVacuum.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as fs from 'fs-extra'
 import { DeviceSettings } from '../api'
 
-export class PreviewVacuum {
+export class PreviewAndThumbnailVacuum {
 	private changes: PouchDB.Core.Changes<MediaObject>
 	constructor(
 		private mediaDB: PouchDB.Database<MediaObject>,
@@ -20,6 +20,7 @@ export class PreviewVacuum {
 	private async rowChanged(id: string, deleted?: boolean) {
 		if (deleted) {
 			await this.deletePreview(id)
+			await this.deleteThumbnail(id)
 		}
 	}
 
@@ -29,10 +30,24 @@ export class PreviewVacuum {
 			this.config.previews && this.config.previews.folder || 'previews',
 			`${mediaId}.webm`
 		)
-		this.logger.info(`PreviewVacuum: deleting preview file "${destPath}" that is no longer required`)
+		this.logger.info(`PreviewAndThumbnailVacuum: deleting preview file "${destPath}" that is no longer required`)
 	  await fs.unlink(destPath).catch((err: NodeJS.ErrnoException) => {
 			if (err.code && err.code !== 'ENOENT' && err.message.indexOf('no such file or directory') === -1) {
-				this.logger.error(`PreviewVacuum: error deleting preview file "${err.stack}"`, err)
+				this.logger.error(`PreviewAndThumbnailVacuum: error deleting preview file "${err.stack}"`, err)
+			}
+	  })
+	}
+
+	private async deleteThumbnail (mediaId: string) {
+		const destPath = path.join(
+			this.config.paths && this.config.paths.resources || '',
+			this.config.thumbnails && this.config.thumbnails.folder || 'thumbs',
+			`${mediaId}.png`
+		)
+		this.logger.info(`PreviewAndThumbnailVacuum: deleting preview file "${destPath}" that is no longer required`)
+		await fs.unlink(destPath).catch((err: NodeJS.ErrnoException) => {
+			if (err.code && err.code !== 'ENOENT' && err.message.indexOf('no such file or directory') === -1) {
+				this.logger.error(`PreviewAndThumbnailVacuum: error deleting thumbnail file "${err.stack}"`, err)
 			}
 	  })
 	}
@@ -44,12 +59,12 @@ export class PreviewVacuum {
 		}).on('change', change => {
 			this.rowChanged(change.id, change.deleted)
 		}).on('error', err => {
-			this.logger.error(`PreviewVacuum: error from change listener`, err)
+			this.logger.error(`PreviewAndThumbnailVacuum: error from change listener`, err)
 		})
 	}
 
 	stop() {
 		this.changes.removeAllListeners()
-		this.logger.info(`PreviewVacuum: no longer reacting to media database changes`)
+		this.logger.info(`PreviewAndThumbnailVacuum: no longer reacting to media database changes`)
 	}
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

A feature to replace the use of PouchDB as the repository for thumbnails and metadata (tbd), serving these to the Sofie UI from a local folder. This will simplify workflows that use both local folder and Quantel-stored assets.

* **What is the current behavior?** (You can also link to an open issue here)

Media manager stores generated thumbnails in the PouchDB database as attachments. These are served to the Sofie UI via a database request.

Media manager mirrors advanced metadata about media assets into Core and into the local pouchDB. This data is served to the Sofie UI via core. Is this the best way? 

* **What is the new behavior (if this is a feature change)?**

Thumbnails are generated and stored in a local resource folder and served to the Sofie UI from that folder rather than Pouch DB.

Metadata is served to the Sofie UI from the optimal source.

* **Other information**:

This is a pull request built on a pull request. The code being changed never existed in master or develop and is still being tested.

The database (pouchdb) is not being changed out as part of this task.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK