### PR TITLE
Feat: Copy files removed from target in WatchFolder flow

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -156,6 +156,8 @@ export interface MediaFlow {
 	sourceId: string
 	/** Id of a Storage */
 	destinationId?: string
+	/** If an item removed from destination should be copied again when still available on source */
+	copyRemoved?: boolean
 	/** Workflow generator type */
 	mediaFlowType: MediaFlowType
 }

--- a/src/configManifest.ts
+++ b/src/configManifest.ts
@@ -109,7 +109,7 @@ MEDIA_MANAGER_MEDIAFLOW_CONFIG[MediaFlowType.UNKNOWN] = [...MEDIA_MANAGER_MEDIAF
 MEDIA_MANAGER_MEDIAFLOW_CONFIG[MediaFlowType.WATCH_FOLDER] = [
 	...MEDIA_MANAGER_MEDIAFLOW_COMMON,
 	{
-		id: 'targetId',
+		id: 'destinationId',
 		name: 'Target Storage',
 		type: ConfigManifestEntryType.STRING // dropdown
 	}
@@ -118,7 +118,7 @@ MEDIA_MANAGER_MEDIAFLOW_CONFIG[MediaFlowType.LOCAL_INGEST] = [...MEDIA_MANAGER_M
 MEDIA_MANAGER_MEDIAFLOW_CONFIG[MediaFlowType.EXPECTED_ITEMS] = [
 	...MEDIA_MANAGER_MEDIAFLOW_COMMON,
 	{
-		id: 'targetId',
+		id: 'destinationId',
 		name: 'Target Storage',
 		type: ConfigManifestEntryType.STRING // dropdown
 	}

--- a/src/configManifest.ts
+++ b/src/configManifest.ts
@@ -112,6 +112,11 @@ MEDIA_MANAGER_MEDIAFLOW_CONFIG[MediaFlowType.WATCH_FOLDER] = [
 		id: 'destinationId',
 		name: 'Target Storage',
 		type: ConfigManifestEntryType.STRING // dropdown
+	},
+	{
+		id: 'copyRemoved',
+		name: 'Copy again files removed on Target',
+		type: ConfigManifestEntryType.BOOLEAN
 	}
 ]
 MEDIA_MANAGER_MEDIAFLOW_CONFIG[MediaFlowType.LOCAL_INGEST] = [...MEDIA_MANAGER_MEDIAFLOW_COMMON]

--- a/src/mediaManager.ts
+++ b/src/mediaManager.ts
@@ -193,7 +193,8 @@ export class MediaManager {
 				this._availableStorage,
 				this._trackedMedia,
 				settings.mediaFlows || [],
-				this._logger
+				this._logger,
+				settings.cronJobTime
 			),
 			new ExpectedItemsGenerator(
 				this._availableStorage,

--- a/src/workflowGenerators/watchFolderGenerator.ts
+++ b/src/workflowGenerators/watchFolderGenerator.ts
@@ -3,12 +3,18 @@ import { getCurrentTime, literal, randomId, getWorkFlowName } from '../lib/lib'
 import { WorkFlow, WorkFlowSource, WorkStep, WorkStepAction, MediaFlow, MediaFlowType, WorkStepStatus } from '../api'
 import { LocalStorageGenerator, WorkFlowGeneratorEventType } from './localStorageGenerator'
 import { File, StorageObject, StorageEvent, StorageEventType } from '../storageHandlers/storageHandler'
-import { TrackedMediaItems } from '../mediaItemTracker'
+import { TrackedMediaItems, TrackedMediaItem } from '../mediaItemTracker'
 import { FileWorkStep } from '../work/workStep'
 import { LoggerInstance } from 'winston'
 
 export class WatchFolderGenerator extends LocalStorageGenerator {
 	private _storageMapping: _.Dictionary<string> = {}
+	private _sourceStoragesWithCronJob: StorageObject[] = []
+	private _destinationStorages: StorageObject[] = []
+	private _cronJob: NodeJS.Timer
+
+	/** The interval of which to check whether some files were deleted. */
+	private CRON_JOB_INTERVAL = 10 * 60 * 1000 // 10 minutes (ms)
 
 	protected ident: string = 'Watch folder generator:'
 
@@ -16,9 +22,11 @@ export class WatchFolderGenerator extends LocalStorageGenerator {
 		availableStorage: StorageObject[],
 		tracked: TrackedMediaItems,
 		flows: MediaFlow[],
-		protected logger: LoggerInstance
+		protected logger: LoggerInstance,
+		cronJobTime?: number
 	) {
 		super(availableStorage, tracked, flows, logger)
+		this.CRON_JOB_INTERVAL = cronJobTime || this.CRON_JOB_INTERVAL
 	}
 
 	async init(): Promise<void> {
@@ -35,15 +43,23 @@ export class WatchFolderGenerator extends LocalStorageGenerator {
 							)
 							return
 						}
-						this.registerStoragePair(srcStorage, dstStorage)
+						this.registerStoragePair(srcStorage, dstStorage, item.copyRemoved)
 					}
 				}
 			})
+
+			this._cronJob = setInterval(() => {
+				this.cronJob()
+			}, this.CRON_JOB_INTERVAL)
 		})
 	}
 
-	protected registerStoragePair(srcStorage: StorageObject, dstStorage: StorageObject) {
+	protected registerStoragePair(srcStorage: StorageObject, dstStorage: StorageObject, withCronJob?: boolean) {
 		this._storageMapping[srcStorage.id] = dstStorage.id
+		if (withCronJob) {
+			this._sourceStoragesWithCronJob.push(srcStorage)
+		}
+		this._destinationStorages.push(dstStorage)
 		super.registerStorage(srcStorage)
 	}
 
@@ -270,5 +286,153 @@ export class WatchFolderGenerator extends LocalStorageGenerator {
 					})
 				})
 			})
+	}
+
+	protected cronJob() {
+		this.logger.debug(`${this.ident} cronJob: Starting cron job for ${this.constructor.name}`)
+		this.logger.debug(`${this.ident} cronJob: Doing storage check`)
+		this._sourceStoragesWithCronJob.forEach(i => this.storageCheck(i))
+	}
+
+	protected async storageCheck(st: StorageObject): Promise<void> {
+		const tmis = await this._tracked.getAllFromStorage(st.id)
+		tmis.forEach(item => this.checkAndEmitCopyWorkflow(item, 'storageCheck'))
+	}
+
+	/**
+	 * Checks if the item exists on the storage and issues workflows
+	 * @param tmi
+	 */
+	protected checkAndEmitCopyWorkflow(tmi: TrackedMediaItem, reason: string) {
+		if (!tmi.sourceStorageId)
+			throw new Error(
+				`${this.ident} checkAndEmitCopyWorkflow: Tracked Media Item "${tmi._id}" has no source storage!`
+			)
+		const storage = this._sourceStoragesWithCronJob.find(i => i.id === tmi.sourceStorageId)
+		if (!storage)
+			throw new Error(`${this.ident} checkAndEmitCopyWorkflow: Could not find storage "${tmi.sourceStorageId}"`)
+
+		// get file from source storage
+		this.getFile(tmi.name, tmi.sourceStorageId)
+			.then(file => {
+				if (file && storage) {
+					file.getProperties()
+						.then(sFileProps => {
+							this._destinationStorages
+								.filter(i => tmi.targetStorageIds.indexOf(i.id) >= 0)
+								.forEach(i => {
+									// check if the file exists on the target storage
+									i.handler.getFile(tmi.name).then(
+										rFile => {
+											// the file exists on target storage
+											rFile.getProperties().then(
+												rFileProps => {
+													if (rFileProps.size !== sFileProps.size) {
+														// File size doesn't match
+														this.emitCopyWorkflow(
+															file,
+															i,
+															tmi.comment,
+															reason,
+															`File size doesn't match on target storage`
+														)
+													}
+												},
+												e => {
+													// Properties could not be fetched
+													this.logger.error(
+														`${this.ident} checkAndEmitCopyWorkflow: ` +
+															`File "${tmi.name}" exists on storage "${i.id}", but it's properties could not be checked. Attempting to write over.`,
+														e
+													)
+													this.emitCopyWorkflow(
+														file,
+														i,
+														tmi.comment,
+														reason,
+														`Could not fetch target file properties`
+													)
+												}
+											)
+										},
+										_err => {
+											// the file not found
+											this.emitCopyWorkflow(
+												file,
+												i,
+												tmi.comment,
+												reason,
+												`File not found on target storage`
+											)
+										}
+									)
+								})
+						})
+						.catch(e => {
+							this.logger.error(
+								`${this.ident} checkAndEmitCopyWorkflow: Could not fetch file "${tmi.name}" properties from storage`,
+								e
+							)
+						})
+				}
+			})
+			.catch(e => {
+				this.logger.error(
+					`${this.ident} checkAndEmitCopyWorkflow: ` +
+						`File "${tmi.name}" failed to be checked in source storage "${tmi.sourceStorageId}"`,
+					e
+				)
+			})
+	}
+
+	private getFile(fileName: string, sourceStorageId: string): Promise<File | undefined> {
+		const sourceStorage = this._sourceStoragesWithCronJob.find(i => i.id === sourceStorageId)
+		if (!sourceStorage) throw new Error(`Source storage "${sourceStorageId}" could not be found.`)
+
+		return new Promise<File | undefined>((resolve, _reject) => {
+			sourceStorage.handler.getFile(fileName).then(
+				file => {
+					resolve(file)
+				},
+				_reason => {
+					resolve(undefined)
+				}
+			)
+		})
+	}
+
+	protected emitCopyWorkflow(
+		file: File,
+		targetStorage: StorageObject,
+		comment: string | undefined,
+		...reason: string[]
+	) {
+		const workflowId = file.name + '_' + randomId()
+		this.emit(
+			WorkFlowGeneratorEventType.NEW_WORKFLOW,
+			literal<WorkFlow>({
+				_id: workflowId,
+				name: getWorkFlowName(file.name),
+				comment: comment,
+				finished: false,
+				priority: 1,
+				source: WorkFlowSource.TARGET_STORAGE_REMOVE,
+				steps: this.generateNewFileWorkSteps(file, targetStorage),
+				created: getCurrentTime(),
+				success: false
+			}),
+			this
+		)
+		this.logger.debug(
+			`${this.ident} emitCopyWorkflow: New forkflow started for "${file.name}": "${workflowId}". ${reason.join(
+				', '
+			)}`
+		)
+	}
+
+	async destroy() {
+		return Promise.resolve().then(() => {
+			clearInterval(this._cronJob)
+		})
 	}
 }


### PR DESCRIPTION
This PR adds an optional cron job feature to WatchFolder flow, that periodically checks for files that are missing on the target storage but are still present on the source storage, and issues a workflow to copy them. 
Option can be enabled per flow, in its settings.