### PR TITLE
Set relative worker job priority via a config manifest setting

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -31,6 +31,9 @@ export interface DeviceSettings {
 	/** Connection details for media access via HTTPS server */
 	httpsPort?: number
 
+	/** Relative priority of copying files and initializing media objects. */
+	copyPriority?: number
+
 	/** A list of Monitors, which will monitor media statuses */
 	monitors?: {
 		[monitorId: string]: MonitorSettings
@@ -54,6 +57,8 @@ export interface DeviceSettings {
 		height?: number
 		/** Sub-folder of `paths.resources` where thumbnails are stored. Defaults to `.../thumbnails` */
 		folder?: string // Not in use yet
+		/** Relative priority of jobs to generate thumbnails */
+		priority?: number
 	}
 
 	/** Configuration for various kinds of advanced metadata generation */
@@ -86,6 +91,9 @@ export interface DeviceSettings {
 
 		/** Merge black and freeze frame detection results. Default is `true` */
 		mergeBlacksAndFreezes?: boolean
+
+		/** Relative prioroty of jobs to create advanced metadata */
+		priority?: number
 	}
 
 	/** Configuration of _hover-scrub_ preview generation */
@@ -100,6 +108,9 @@ export interface DeviceSettings {
 		bitrate?: string
 		/** Sub-folder of `paths.resources` where thumbnails are stored. Defaults to `.../previews` */
 		folder?: string
+
+		/** Relative priority of jobs to generate previews */
+		priority?: number
 	}
 }
 

--- a/src/configManifest.ts
+++ b/src/configManifest.ts
@@ -234,6 +234,18 @@ export const MEDIA_MANAGER_CONFIG_MANIFEST: DeviceConfigManifest = {
 			type: ConfigManifestEntryType.STRING
 		},
 		{
+			id: 'copyPriority',
+			name: 'Copy and initial check priority',
+			type: ConfigManifestEntryType.NUMBER,
+			placeholder: '2.0'
+		},
+		{
+			id: 'thumbnails.priority',
+			name: 'Thumbnail generation priority',
+			type: ConfigManifestEntryType.NUMBER,
+			placeholder: '0.5'
+		},
+		{
 			id: 'thumbnails.width',
 			name: 'Thumbnail width',
 			type: ConfigManifestEntryType.INT,
@@ -250,6 +262,12 @@ export const MEDIA_MANAGER_CONFIG_MANIFEST: DeviceConfigManifest = {
 			name: 'Thumbnail sub-folder',
 			type: ConfigManifestEntryType.STRING,
 			placeholder: 'thumbs'
+		},
+		{
+			id: 'metadata.priority',
+			name: 'Metadata generation priority',
+			type: ConfigManifestEntryType.NUMBER,
+			placeholder: '1.0'
 		},
 		{
 			id: 'metadata.fieldOrder',
@@ -322,6 +340,12 @@ export const MEDIA_MANAGER_CONFIG_MANIFEST: DeviceConfigManifest = {
 			id: 'previews.enable',
 			name: 'Enable preview generation',
 			type: ConfigManifestEntryType.BOOLEAN
+		},
+		{ 
+			id: 'previews.priority',
+			name: 'Preview generation priority',
+			type: ConfigManifestEntryType.NUMBER,
+			placeholder: '0.3'
 		},
 		{
 			id: 'previews.width',

--- a/src/configManifest.ts
+++ b/src/configManifest.ts
@@ -341,7 +341,7 @@ export const MEDIA_MANAGER_CONFIG_MANIFEST: DeviceConfigManifest = {
 			name: 'Enable preview generation',
 			type: ConfigManifestEntryType.BOOLEAN
 		},
-		{ 
+		{
 			id: 'previews.priority',
 			name: 'Preview generation priority',
 			type: ConfigManifestEntryType.NUMBER,

--- a/src/mediaManager.ts
+++ b/src/mediaManager.ts
@@ -202,7 +202,11 @@ export class MediaManager {
 				this.coreHandler,
 				this._logger,
 				settings.lingerTime,
-				settings.cronJobTime
+				settings.cronJobTime,
+				settings.copyPriority,
+				settings.metadata?.priority,
+				settings.thumbnails?.priority,
+				settings.previews?.priority
 			)
 		)
 

--- a/src/workflowGenerators/expectedItemsGenerator.ts
+++ b/src/workflowGenerators/expectedItemsGenerator.ts
@@ -73,7 +73,11 @@ export class ExpectedItemsGenerator extends BaseWorkFlowGenerator {
 		coreHandler: CoreHandler,
 		private logger: LoggerInstance,
 		lingerTime?: number,
-		cronJobTime?: number
+		cronJobTime?: number,
+		private copyPriority?: number,
+		private metadataPriority?: number,
+		private thumbnailPriority?: number,
+		private previewPriority?: number
 	) {
 		super(logger)
 		this._allStorages = availableStorage
@@ -732,7 +736,7 @@ export class ExpectedItemsGenerator extends BaseWorkFlowGenerator {
 					action: WorkStepAction.COPY,
 					file: file,
 					target: st,
-					priority: 2,
+					priority: this.copyPriority || 2.0,
 					criticalStep: true,
 					status: WorkStepStatus.IDLE
 				})
@@ -743,7 +747,7 @@ export class ExpectedItemsGenerator extends BaseWorkFlowGenerator {
 					action: WorkStepAction.SCAN,
 					file,
 					target: st,
-					priority: 2,
+					priority: this.copyPriority || 2.0,
 					criticalStep: true,
 					status: WorkStepStatus.IDLE
 				})
@@ -754,21 +758,21 @@ export class ExpectedItemsGenerator extends BaseWorkFlowGenerator {
 				action: WorkStepAction.GENERATE_METADATA,
 				file,
 				target: st,
-				priority: 1,
+				priority: this.metadataPriority || 1.0,
 				status: WorkStepStatus.IDLE
 			}),
 			new ScannerWorkStep({
 				action: WorkStepAction.GENERATE_THUMBNAIL,
 				file,
 				target: st,
-				priority: 0.5,
+				priority: this.thumbnailPriority || 0.5,
 				status: WorkStepStatus.IDLE
 			}),
 			new ScannerWorkStep({
 				action: WorkStepAction.GENERATE_PREVIEW,
 				file,
 				target: st,
-				priority: 0.3,
+				priority: this.previewPriority || 0.3,
 				status: WorkStepStatus.IDLE
 			})
 		)


### PR DESCRIPTION
Feature to expose relative job priorities for different kinds of media manager work as a setting via config manifests.