### PR TITLE
fix: Processing image files

### DIFF
--- a/src/work/worker.ts
+++ b/src/work/worker.ts
@@ -660,8 +660,12 @@ export class Worker {
 			return {}
 		}
 
-		if (!doc.mediainfo || !doc.mediainfo.format || !doc.mediainfo.format.duration) {
+		if (!doc.mediainfo || !doc.mediainfo.format) {
 			throw new Error('Worker: get metadata: running getMetadata requires the presence of basic file data first.')
+		}
+		if (!doc.mediainfo.format.duration) {
+			this.logger.info(`Worker: get metadata: not generating stream metadata: duration missing on "${doc.mediaId}"`)
+			return {}
 		}
 
 		let filterString = ''


### PR DESCRIPTION
Image files are treated as video but some of them (eg. specific PNGs) will not have `mediainfo.format.duration` set in the metadata obtained from FFprobe, which makes the workstep generating Advanced Metadata fail.
Instead of throwing an exception in this case, log appropriate info and skip generating advanced metadata in order to allow next steps (thumbnails generation etc.) to execute.