### PR TITLE
Fix: race condition causing db conflict

### DIFF
--- a/src/work/worker.ts
+++ b/src/work/worker.ts
@@ -1132,17 +1132,16 @@ export class Worker {
 			this.logger.debug(`Worker: metadata generate: new info size is ${mediaSize}`)
 		}
 
-		// Read document again ... might have been updated while we were busy working
-		if (docExists) {
-			let { result: doc2, error: getError2 } = await noTryAsync(() => this.mediaDB.get<MediaObject>(fileId))
-			if (getError2) {
-				return this.failStep(
-					`after work, failed to retrieve media object with ID "${fileId}"`,
-					step.action,
-					getError2
-				)
-			}
+		// Read document again ... might have been created or updated while we were busy working
+		let { result: doc2, error: getError2 } = await noTryAsync(() => this.mediaDB.get<MediaObject>(fileId))
+		if (!getError2) {
 			doc = doc2
+		} else if (docExists) {
+			return this.failStep(
+				`after work, failed to retrieve media object with ID "${fileId}"`,
+				step.action,
+				getError2
+			)
 		}
 		doc.mediainfo = Object.assign(doc.mediainfo || {}, newInfo)
 		this.logger.debug(`Worker: media clip is`, doc)


### PR DESCRIPTION
The document that did not exist at the beginning of doGenerateMetadata might get created by a watcher when worker is busy. In that case, It would result in a failed workstep.
Fix: Try to get the doc again, even if it didn't exist. Fail only if the doc was removed in the meantime.