### PR TITLE
Fix: stop quantel watchers from crashing and restart if they do

### DIFF
--- a/src/monitors/quantel.ts
+++ b/src/monitors/quantel.ts
@@ -285,9 +285,10 @@ export class MonitorQuantel extends Monitor {
 		setTimeout(() => {
 			if (!this.isDestroyed) {
 				this.doWatch().catch(e => {
-					this.logger.error(`${this.ident} triggerWatch: Error in Quantel doWatch`, e)
+					this.logger.error(`${this.ident} triggerWatch: Error in Quantel doWatch - retarting watcher in 10s`, e)
 				})
 			}
+			setTimeout(this.triggerWatch, 10000)
 		}, BREATHING_ROOM)
 	}
 
@@ -332,9 +333,9 @@ export class MonitorQuantel extends Monitor {
 							return (
 								typeof clipData.PoolID === 'number' &&
 								(server.pools || []).indexOf(clipData.PoolID) !== -1 && // If present in any of the pools of the server
-								parseInt(clipData.Frames, 10) > 0 &&
-								clipData.Completed !== null &&
-								clipData.Completed.length > 0 // Note from Richard: Completed might not necessarily mean that it's completed on the right server
+								parseInt(clipData.Frames, 10) > 0 // && 5/5/21: Removed check for completed - OA tests shoes it does nothing for placeholders
+								// clipData.Completed !== null &&
+								// clipData.Completed.length > 0 // Note from Richard: Completed might not necessarily mean that it's completed on the right server
 							)
 						}).sort(
 							(
@@ -342,7 +343,7 @@ export class MonitorQuantel extends Monitor {
 								b // Sort Created dates into reverse order
 							) => new Date(b.Created).getTime() - new Date(a.Created).getTime()
 						)
-						if (clipSummaryOnPool) {
+						if (clipSummaryOnPool && clipSummaryOnPool.length > 0) {
 							// The clip is present, and on the right server
 							this.logger.debug(
 								`${this.ident} doWatch: Clip "${url}" found with ${clipSummaryOnPool.length} mathcing clips`


### PR DESCRIPTION
This is a bugfix. The watcher was crashing when it encountered its first placeholder of the day. The quantel watcher had no mechanism to auto-restart. 

The watcher should no longer crash when it encounters an empty list of clip summaries. Also, the watcher will now restart 10 seconds after a failure.

This PR also removes the completed check. A manual test showed this to be irrelevant as the completed value is set for clips whether placeholders, still publishing or published. It is updated at the end of a publish ... but this does not really help Sofie.