### PR TITLE
fix: make sure two+ files with freeze frames don't cause a crash

### DIFF
--- a/src/work/worker.ts
+++ b/src/work/worker.ts
@@ -643,13 +643,15 @@ export class Worker {
 		return fieldOrder
 	}
 
-	private static readonly sceneRegex = /Parsed_showinfo_(.*)pts_time:([\d.]+)\s+/g
-	private static readonly blackDetectRegex = /(black_start:)(\d+(.\d+)?)( black_end:)(\d+(.\d+)?)( black_duration:)(\d+(.\d+))?/g
-	private static readonly freezeDetectStart = /(lavfi\.freezedetect\.freeze_start: )(\d+(.\d+)?)/g
-	private static readonly freezeDetectDuration = /(lavfi\.freezedetect\.freeze_duration: )(\d+(.\d+)?)/g
-	private static readonly freezeDetectEnd = /(lavfi\.freezedetect\.freeze_end: )(\d+(.\d+)?)/g
-
 	private async getMetadata(doc: MediaObject): Promise<Metadata> {
+		
+		// No longer static because /g flag has states between each run
+		const sceneRegex = /Parsed_showinfo_(.*)pts_time:([\d.]+)\s+/g
+		const blackDetectRegex = /(black_start:)(\d+(.\d+)?)( black_end:)(\d+(.\d+)?)( black_duration:)(\d+(.\d+))?/g
+		const freezeDetectStart = /(lavfi\.freezedetect\.freeze_start: )(\d+(.\d+)?)/g
+		const freezeDetectDuration = /(lavfi\.freezedetect\.freeze_duration: )(\d+(.\d+)?)/g
+		const freezeDetectEnd = /(lavfi\.freezedetect\.freeze_end: )(\d+(.\d+)?)/g
+
 		const metaconf = this.config.metadata
 		if (!metaconf || (!metaconf.scenes && !metaconf.freezeDetection && !metaconf.blackDetection)) {
 			this.logger.debug(
@@ -737,11 +739,11 @@ export class Worker {
 			}
 
 			let res: RegExpExecArray | null
-			while ((res = Worker.sceneRegex.exec(stringData)) !== null) {
+			while ((res = sceneRegex.exec(stringData)) !== null) {
 				scenes.push(parseFloat(res[2]))
 			}
 
-			while ((res = Worker.blackDetectRegex.exec(stringData)) !== null) {
+			while ((res = blackDetectRegex.exec(stringData)) !== null) {
 				blacks.push(
 					literal<Anomaly>({
 						start: parseFloat(res[2]),
@@ -751,7 +753,7 @@ export class Worker {
 				)
 			}
 
-			while ((res = Worker.freezeDetectStart.exec(stringData)) !== null) {
+			while ((res = freezeDetectStart.exec(stringData)) !== null) {
 				freezes.push(
 					literal<Anomaly>({
 						start: parseFloat(res[2]),
@@ -762,12 +764,12 @@ export class Worker {
 			}
 
 			let i = 0
-			while ((res = Worker.freezeDetectDuration.exec(stringData)) !== null) {
+			while ((res = freezeDetectDuration.exec(stringData)) !== null) {
 				freezes[i++].duration = parseFloat(res[2])
 			}
 
 			i = 0
-			while ((res = Worker.freezeDetectEnd.exec(stringData)) !== null) {
+			while ((res = freezeDetectEnd.exec(stringData)) !== null) {
 				freezes[i++].end = parseFloat(res[2])
 			}
 		})

--- a/src/work/worker.ts
+++ b/src/work/worker.ts
@@ -765,12 +765,16 @@ export class Worker {
 
 			let i = 0
 			while ((res = freezeDetectDuration.exec(stringData)) !== null) {
-				freezes[i++].duration = parseFloat(res[2])
+				if (freezes[i]) { 
+					freezes[i++].duration = parseFloat(res[2])
+				}
 			}
 
 			i = 0
 			while ((res = freezeDetectEnd.exec(stringData)) !== null) {
-				freezes[i++].end = parseFloat(res[2])
+				if (freezes[i]) {
+					freezes[i++].end = parseFloat(res[2])
+				}
 			}
 		})
 


### PR DESCRIPTION
Fix an issue where global regular expressions did not necessarily reset between runs of workers, meaning in some circumstances a freeze frame anomoly entry was not created when the duration was set on it. 